### PR TITLE
Proofread of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ To understand the reasoning behind its creation, please read [Rethinking CSS](/r
     - [Debug: `$hu-debug`](#debug-hu-debug)
   - [Classes](#classes)
 - [Creating custom classes](#creating-custom-classes)
-  - [Customising "placeholder" classes](#customising-placeholder-classes)
-  - [Creating new, "basic" classes](#creating-new-basic-classes)
+  - [Customising “placeholder” classes](#customising-placeholder-classes)
+  - [Creating new, “basic” classes](#creating-new-basic-classes)
     - [Generic classes: `hu-classes`](#generic-classes-hu-classes)
       - [Basic](#basic)
       - [Custom class name](#custom-class-name)
       - [Unique class with multiple declarations](#unique-class-with-multiple-declarations)
     - [Pseudo classes: `hu-pseudo-classes`](#pseudo-classes-hu-pseudo-classes)
     - [Parent classes: `hu-parent-classes`](#parent-classes-hu-parent-classes)
-  - [Creating new, "more complex" classes](#creating-new-more-complex-classes)
+  - [Creating new, “more complex” classes](#creating-new-more-complex-classes)
     - [Helper Functions](#helper-functions)
       - [`hu-class-name`](#hu-class-name)
       - [`hu-format-modules`](#hu-format-modules)
@@ -86,13 +86,13 @@ To understand the reasoning behind its creation, please read [Rethinking CSS](/r
 
 ## What's in the box?
 
-Currently, Hucssley provides utility classes for over 110 CSS properties, of which multiple, sensible default values are generated. Each utility is also created for various "modules", whether that's at certain breakpoints, UI states, user interactions, for print or more.
+Currently, Hucssley provides utility classes for over 110 CSS properties, of which multiple, sensible default values are generated. Each utility is also created for various “modules”, whether that's at certain breakpoints, UI states, user interactions, for print or more.
 
 Each utility is completely customisable; they can be partially renamed, have values changed, have their modules altered or be omitted entirely.
 
 By default, Hucssley does not output classes for things that don't map explicitly to specific property types (such as `box-shadow`, background gradients and `transform`), but it does provide placeholder variables for these to make tailored, [custom classes simple to create](#creating-custom-classes).
 
-Hucssley also provides utility classes for truncating text and making elements "visually hidden" for accessibility purposes.
+Hucssley also provides utility classes for truncating text and making elements “visually hidden” for accessibility purposes.
 
 For a complete list of the class names provided, read [Hucssley classes](/hucssley-classes.md).
 
@@ -103,7 +103,7 @@ Hucssley also comes with:
 * Functions to incrementally darken (`shade`) or lighten (`tint`) colours.
 * The ability to theme elements based off a parent selector.
 * The ability to create classes scoped to custom parent selectors.
-* The ability to create classes the map to pseudo-classes and pseudo-selectors.
+* The ability to create classes that map to pseudo-classes and pseudo-selectors.
 
 ---
 
@@ -191,9 +191,9 @@ The following example demonstrates how you can use Hucssley out-of-the-box to ea
 
 With [so many CSS utility libraries](https://css-tricks.com/need-css-utility-library/) already in existence, and with Tailwind being an extremely popular, close alternative, why does Hucssley exist and why might you want to use it?
 
-We wanted to [solve a lot of the problems](/rethinking-css.md) developers have with "normal" CSS and the ones Adam Silver poses in [The problem with atomic CSS](https://adamsilver.io/articles/the-problem-with-atomic-css/).
+We wanted to [solve a lot of the problems](/rethinking-css.md) developers have with “normal” CSS and the ones Adam Silver poses in [The problem with atomic CSS](https://adamsilver.io/articles/the-problem-with-atomic-css/).
 
-Firstly, most utility libraries are hard to read, and more importantly hard to learn. They often use an obtuse, inconsistent syntax which has you reaching for the docs more often than you should. With Hucssley, the focus has been: "if you know CSS properties, you know Hucssley".
+Firstly, most utility libraries are hard to read, and more importantly hard to learn. They often use an obtuse, inconsistent syntax which has you reaching for the docs more often than you should. With Hucssley, the focus has been: “if you know CSS properties, you know Hucssley”.
 
 Also, by using Sass under the hood, it supports an extremely deep pool of developers who already know the language and its wealth of features, and has great documentation and resources to boot.
 
@@ -290,7 +290,7 @@ translate-x -> transform: translateX
 translate-y -> transform: translateY
 ```
 
-If a value is a negative number, its class name output will use `-n[value]`, such as `margin-l-n100` instead of `margin-l--100`, to make it obvious that it's "negative" and to not be confused with the "modifying" syntax described below. 
+If a value is a negative number, its class name output will use `-n[value]`, such as `margin-l-n100` instead of `margin-l-100`, to make it obvious that it's “negative” and to not be confused with the “modifying” syntax described below.
 
 If the last two words separated by a hyphen are identical, then the last word will automatically be omitted. For instance `.flex-wrap` is used instead of `flex-wrap-wrap`, but `flex-wrap-no-wrap` would be the equivalent `nowrap` version.
 
@@ -298,7 +298,7 @@ If the last two words separated by a hyphen are identical, then the last word wi
 
 #### Non-parent modules: `focus, hocus, hover, print, reduced-motion, responsive`
 
-When you want to use class names scoped to "non-parent" modules, it follows a pattern of `[module-name][-module-variant])?--[base-class]`, for instance:
+When you want to use class names scoped to “non-parent” modules, it follows a pattern of `[module-name][-module-variant])?--[base-class]`, for instance:
 
 ```css
 .bp-768--align-items-center
@@ -372,7 +372,7 @@ Here the syntax is `bp-[responsive-scale]-[state-name]--[base-class]` for states
 
 ## Scales
 
-Where it makes sense, and compared with other libraries, Hucssley favours a millennial scale (`0` - `1000`) to represent values instead of "names" like `xxl`, `mama-bear` etc. This can of course be completely customised.
+Where it makes sense, and compared with other libraries, Hucssley favours a millennial scale (`0` - `1000`) to represent values instead of “names” like `xxl`, `mama-bear` etc. This can of course be completely customised.
 
 By default, the following classes use a millennial scale:
 
@@ -397,7 +397,7 @@ To override the default configuration in Hucssley, you'll need to understand the
 
 Hucssley's configuration is split in to 3 sections: `reset`, `global` and `classes`.
 
-* **Reset** configuration uses plain variables to customise "generic" styles like whether `box-sizing: border-box` should be used by default.
+* **Reset** configuration uses plain variables to customise “generic” styles like whether `box-sizing: border-box` should be used by default.
 * **Global** configuration mostly uses maps to handle things like the default responsive breakpoints, colors, spacings, UI states and themes.
 * **Classes** provides list and map variables to adjust the modules, and values for each class individually. Some classes (like those which deal with color) inherit from the same base variable by default, so only 1 change is required to affect all `border-color`, `background-color` and `color` classes. All classes can be generated at individual modules described above.
 
@@ -762,7 +762,7 @@ $hu-focus-pseudo: ":focus:not(.focus-visible)";
 
 #### Themes: `$hu-themes`
 
-As well as the standard `$hu-colors`, "color" classes can also be generated for theming your application based on the key/vaue pairs in this map.
+As well as the standard `$hu-colors`, “color” classes can also be generated for theming your application based on the key/vaue pairs in this map.
 
 By default, no themes are provided, but making your own is easy:
 
@@ -830,9 +830,9 @@ Every class in Hucssley can be completely customised to individually change the 
 
 While Hucssley provides an abundance of classes out-of-the-box, there will absolutely be times where you need to create your own to achieve your desired UI, which is hopefully straight-forward to achieve.
 
-### Customising "placeholder" classes
+### Customising “placeholder” classes
 
-Some of the default classes in Hucssley are merely provided as empty placeholders, because their usage is too specific to be generically useful for all projects. These placeholders help to reduce some of the "ceremony" needed with creating completely custom classes.
+Some of the default classes in Hucssley are merely provided as empty placeholders, because their usage is too specific to be generically useful for all projects. These placeholders help to reduce some of the “ceremony” needed with creating completely custom classes.
 
 A good example of this is for (box) shadows. By overriding the empty `$hu-box-shadow-modules` and `$hu-box-shadow-types` variables, developers can easily output `box-shadow`s appropriate for their project.
 
@@ -859,9 +859,9 @@ will generate:
 }
 ```
 
-### Creating new, "basic" classes
+### Creating new, “basic” classes
 
-For the most common needs of creating new classes, Hucssley provides 3 easy ways of creating custom "generic", pseudo and parent utility classes.
+For the most common needs of creating new classes, Hucssley provides 3 easy ways of creating custom “generic”, pseudo and parent utility classes.
 
 While the following examples all use `$-modules` and `$-types` variables that are provided by Hucssley, if creating your own, fully custom classes, we recommend setting them up in a way to cater for any complexity as your project grows, thus define the variables similarly to how the defaults are done. For examples and to learn more, please read [Hucssley classes](/hucssley-classes.md).
 
@@ -939,7 +939,7 @@ By passing a map to `$property`, the map's key becomes the core class name, and 
 
 ##### Unique class with multiple declarations
 
-By not proving a `$type` and passing in a `@content` block, you can create "one off" classes with multiple, static declarations.
+By not proving a `$type` and passing in a `@content` block, you can create “one off” classes with multiple, static declarations.
 
 ```scss
 @include hu-classes(font-smoothing, $hu-font-smoothing-modules) {
@@ -1056,7 +1056,7 @@ Another benefit of Hucssley is that you can easily create custom parent classes,
 
 As with `$hu-classes`, you can customise the class name by passing a map to `$property`, and you can create unique classes with multiple declarations by not proving a `$type` and passing in a `@content` block.
 
-### Creating new, "more complex" classes
+### Creating new, “more complex” classes
 
 Should you need to create classes that are more complex than what the 3 basic mixins described above can provide, you can follow a defined pattern for creating your own. However, before you do, it's worth having a basic understanding of the functions and mixins you'll use.
 
@@ -1290,7 +1290,7 @@ Although the mixins described above can take a list of modules, to ensure the co
     // call hu-generic with the $class-name and $module
     @include hu-generic($class-name, $module) {
       // write your declarations, using $value as the CSS value
-      height: $value; 
+      height: $value;
       width: $value;
     }
   }
@@ -1316,7 +1316,7 @@ The above loop doesn't generate the responsive classes. If we generated them wit
         // call hu-responsive with the $class-name, *all* modules and $bp-scale
         @include hu-responsive($class-name, $icon-size-modules, $bp-scale) {
           // write your declarations, using $value as the CSS value
-          height: $value; 
+          height: $value;
           width: $value;
         }
       }
@@ -1367,7 +1367,7 @@ The output from these 2 blocks is:
 
 ##### Creating custom pseudo classes
 
-One benefit Hucssley has over other, similar libraries is that there is a defined method for easily creating pseudo classes. As with "generic" classes, you'll need 2 code blocks, but instead of calling `hu-generic` and `hu-responsive`, you call `hu-pseudo` and `hu-pseudo-responsive` with the appropriate, documented arguments.
+One benefit Hucssley has over other, similar libraries is that there is a defined method for easily creating pseudo classes. As with “generic” classes, you'll need 2 code blocks, but instead of calling `hu-generic` and `hu-responsive`, you call `hu-pseudo` and `hu-pseudo-responsive` with the appropriate, documented arguments.
 
 ```scss
 // loop through the formatted modules in order
@@ -1382,7 +1382,7 @@ One benefit Hucssley has over other, similar libraries is that there is a define
     // call hu-pseudo with the $class-name, pseudo selectors and $module
     @include hu-pseudo($class-name, ("::before"), $module) {
       // write your declarations, using $value as the CSS value
-      height: $value; 
+      height: $value;
       width: $value;
     }
   }
@@ -1404,7 +1404,7 @@ One benefit Hucssley has over other, similar libraries is that there is a define
         // call hu-pseudo responsive with the $class-name, pseudo selectors, *all* modules and $bp-scale
         @include hu-pseudo-responsive($class-name, ("::before"), $icon-size-modules, $bp-scale) {
           // write your declarations, using $value as the CSS value
-          height: $value; 
+          height: $value;
           width: $value;
         }
       }
@@ -1470,7 +1470,7 @@ Similarly, custom parent classes can also easily be generated with the `hu-paren
     // call hu-parent with the $class-name, parent selectors and $module
     @include hu-parent($class-name, (browser-mobile), $module) {
       // write your declarations, using $value as the CSS value
-      height: $value; 
+      height: $value;
       width: $value;
     }
   }
@@ -1492,7 +1492,7 @@ Similarly, custom parent classes can also easily be generated with the `hu-paren
         // call hu-parent-responsive with the $class-name, parent selectors, *all* modules and $bp-scale
         @include hu-parent-responsive($class-name, (browser-mobile), $icon-size-modules, $bp-scale) {
           // write your declarations, using $value as the CSS value
-          height: $value; 
+          height: $value;
           width: $value;
         }
       }
@@ -1543,9 +1543,9 @@ will generate the following:
 
 ## Creating components
 
-Since Hucssley outputs raw HTML class names, it's incredibly easy to integrate with any front-end "view" framework, to create custom components with small and simple styling APIs.
+Since Hucssley outputs raw HTML class names, it's incredibly easy to integrate with any front-end “view” framework, to create custom components with small and simple styling APIs.
 
-By using raw class name strings, you are also able to annotate browser-specifc fixes alongside them in the HTML, which helps with understanding why "unnecessary" properties are there.
+By using raw class name strings, you are also able to annotate browser-specifc fixes alongside them in the HTML, which helps with understanding why “unnecessary” properties are there.
 
 Let's create a button in Vue:
 
@@ -1790,7 +1790,7 @@ which produces:
 
 ## Controlling file size
 
-While Hucssley creates almost every possible class you'd ever want to make building UI simple, this comes at a file size cost with the OOTB CSS coming in at a massive 1.8 MB. Of course, the nature of Hucssley lends itself very well to gzipping, which brings the OOTB CSS down to 114 KB, which ironically, is still a lot smaller than lots of other "production" CSS in the wild.
+While Hucssley creates almost every possible class you'd ever want to make building UI simple, this comes at a file size cost with the OOTB CSS coming in at a massive 1.8 MB. Of course, the nature of Hucssley lends itself very well to gzipping, which brings the OOTB CSS down to 114 KB, which ironically, is still a lot smaller than lots of other “production” CSS in the wild.
 
 Hucssley is infinitely customisable, so you can set the variables of modules you'll never use to `()` so they won't output, and of course, limiting the amount of colors, breakpoints, and spacing scales will also help.
 
@@ -1802,4 +1802,4 @@ extractor: class {
     return content.match(/(?:[A-Za-z0-9]|-|_|:|<|>|@)+/g) || [];
   }
 },
-``` 
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It honours the groundwork laid by earlier utility class libraries such as [Tachy
 To that end, Hucssley has a few goals:
 
 1. To be incredibly easy to learn and use, by providing a system of atomic classes that mostly map 1:1 with existing CSS properties.
-2. To allow anyone of any skill to rapidly build for the web without unknowingly causing CSS bloat or fighting against some of CSS's core, but sometimes difficult to understand principals.
+2. To allow anyone of any skill to rapidly build for the web without unknowingly causing CSS bloat or fighting against some of CSS’s core, but sometimes difficult to understand principals.
 3. To provide the tools required to build UI for any breakpoint, user interaction or UI state.
 4. To be completely platform agnostic and portable between front-end stacks, with Sass being the only dependency.
 5. To be highly flexible to your needs, with the ability to easily customise existing classes and create new ones.
@@ -20,7 +20,7 @@ To understand the reasoning behind its creation, please read [Rethinking CSS](/r
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [What's in the box?](#whats-in-the-box)
+- [What’s in the box?](#whats-in-the-box)
 - [A working example](#a-working-example)
 - [Why Hucssley?](#why-hucssley)
 - [Installation](#installation)
@@ -84,13 +84,13 @@ To understand the reasoning behind its creation, please read [Rethinking CSS](/r
 
 ---
 
-## What's in the box?
+## What’s in the box?
 
-Currently, Hucssley provides utility classes for over 110 CSS properties, of which multiple, sensible default values are generated. Each utility is also created for various “modules”, whether that's at certain breakpoints, UI states, user interactions, for print or more.
+Currently, Hucssley provides utility classes for over 110 CSS properties, of which multiple, sensible default values are generated. Each utility is also created for various “modules”, whether that’s at certain breakpoints, UI states, user interactions, for print or more.
 
 Each utility is completely customisable; they can be partially renamed, have values changed, have their modules altered or be omitted entirely.
 
-By default, Hucssley does not output classes for things that don't map explicitly to specific property types (such as `box-shadow`, background gradients and `transform`), but it does provide placeholder variables for these to make tailored, [custom classes simple to create](#creating-custom-classes).
+By default, Hucssley does not output classes for things that don’t map explicitly to specific property types (such as `box-shadow`, background gradients and `transform`), but it does provide placeholder variables for these to make tailored, [custom classes simple to create](#creating-custom-classes).
 
 Hucssley also provides utility classes for truncating text and making elements “visually hidden” for accessibility purposes.
 
@@ -197,11 +197,11 @@ Firstly, most utility libraries are hard to read, and more importantly hard to l
 
 Also, by using Sass under the hood, it supports an extremely deep pool of developers who already know the language and its wealth of features, and has great documentation and resources to boot.
 
-With other libraries, while the initial implementation period is very promising, it's when you hit the harder, more uncommon issues that you start to struggle. Out-of-the-box, Hucssley wants to provide you with all of the tools to build any UI regardless of the condition. This means we support every type of width media query, theming, pseudo selectors, user interaction states (`:hover`, `:focus-visible`), UI states (`is-expanded`, `is-loading`), and any kind of parent selector (for use with things like browser detection libraries, or element query polyfills).
+With other libraries, while the initial implementation period is very promising, it’s when you hit the harder, more uncommon issues that you start to struggle. Out-of-the-box, Hucssley wants to provide you with all of the tools to build any UI regardless of the condition. This means we support every type of width media query, theming, pseudo selectors, user interaction states (`:hover`, `:focus-visible`), UI states (`is-expanded`, `is-loading`), and any kind of parent selector (for use with things like browser detection libraries, or element query polyfills).
 
-Lastly, Hucssley tries to be extremely flexible and easily configurable. While it provides many more classes and features than other libraries OOTB, if it doesn't provide something you need, it's hopefully very easy to build what you need in a consistent, Hucssley manner.
+Lastly, Hucssley tries to be extremely flexible and easily configurable. While it provides many more classes and features than other libraries OOTB, if it doesn’t provide something you need, it’s hopefully very easy to build what you need in a consistent, Hucssley manner.
 
-So with you now intrigued, read the rest of the docs, have a play, and fall in love building UI…
+So with you now intrigued, read the rest of the docs, have a play, and fall in love with building UI…
 
 ---
 
@@ -211,7 +211,7 @@ So with you now intrigued, read the rest of the docs, have a play, and fall in l
 npm install github:stowball/hucssley#master
 ```
 
-If you want to use Hucssley as it comes, then it's as simple as:
+If you want to use Hucssley as it comes, then it’s as simple as:
 
 ```scss
 @import "../node_modules/hucssley/src/index";
@@ -227,7 +227,7 @@ However, if you want to customise Hucssley, we recommend taking this approach:
 
 @import "../node_modules/hucssley/src/variables/classes/index";
 // @import "custom/variables/classes/index";
-// set class overrides before if you don't need access to the defaults & want changes to flow through referenced vars
+// set class overrides before if you don’t need access to the defaults & want changes to flow through referenced vars
 
 @import "../node_modules/hucssley/src/variables/reset/index";
 // @import "custom/variables/reset/index";
@@ -290,7 +290,7 @@ translate-x -> transform: translateX
 translate-y -> transform: translateY
 ```
 
-If a value is a negative number, its class name output will use `-n[value]`, such as `margin-l-n100` instead of `margin-l-100`, to make it obvious that it's “negative” and to not be confused with the “modifying” syntax described below.
+If a value is a negative number, its class name output will use `-n[value]`, such as `margin-l-n100` instead of `margin-l-100`, to make it obvious that it’s “negative” and to not be confused with the “modifying” syntax described below.
 
 If the last two words separated by a hyphen are identical, then the last word will automatically be omitted. For instance `.flex-wrap` is used instead of `flex-wrap-wrap`, but `flex-wrap-no-wrap` would be the equivalent `nowrap` version.
 
@@ -355,7 +355,7 @@ For `group` classes to take effect, a parent has to be given the raw `.group` cl
 </html>
 ```
 
-Be careful when using groups, because they will affect all `.group__` children. A child `.group` does not reset the actions of a parent `.group`, so you could end up with unexpected behaviour. It's recommended to use groups on near ancestors to leaf nodes.
+Be careful when using groups, because they will affect all `.group__` children. A child `.group` does not reset the actions of a parent `.group`, so you could end up with unexpected behaviour. It’s recommended to use groups on near ancestors to leaf nodes.
 
 *Note: `.browser-mobile` is an example of a custom parent selector, and is not included in Hucssley by default.*
 
@@ -393,9 +393,9 @@ While others, like `opacity` and `scale` use values more relevant to your concep
 
 ## Configuration
 
-To override the default configuration in Hucssley, you'll need to understand the basic syntax of Sass [variables](https://sass-lang.com/documentation/variables), [lists](https://sass-lang.com/documentation/values/lists) and [maps](https://sass-lang.com/documentation/values/maps).
+To override the default configuration in Hucssley, you’ll need to understand the basic syntax of Sass [variables](https://sass-lang.com/documentation/variables), [lists](https://sass-lang.com/documentation/values/lists) and [maps](https://sass-lang.com/documentation/values/maps).
 
-Hucssley's configuration is split in to 3 sections: `reset`, `global` and `classes`.
+Hucssley’s configuration is split in to 3 sections: `reset`, `global` and `classes`.
 
 * **Reset** configuration uses plain variables to customise “generic” styles like whether `box-sizing: border-box` should be used by default.
 * **Global** configuration mostly uses maps to handle things like the default responsive breakpoints, colors, spacings, UI states and themes.
@@ -658,7 +658,7 @@ would generate the following `bp-` classes:
 }
 ```
 
-Notice how, apart from the `bp-` prefix, Hucssley does not dictate the breakpoint class name format, so, should you wish to use ranges like `small` or `medium`, or device types like `tablet`, or `desktop`, it's entirely up to you.
+Notice how, apart from the `bp-` prefix, Hucssley does not dictate the breakpoint class name format, so, should you wish to use ranges like `small` or `medium`, or device types like `tablet`, or `desktop`, it’s entirely up to you.
 
 #### UI states: `$hu-states`
 
@@ -704,7 +704,7 @@ You can easily amend or override any of these values to suit your project.
 
 #### Borders: `$hu-border-modules`, `$hu-border-sides` and `$hu-border-types`
 
-By default, `.border-color-`, `.border-style-` and `.border-width-` classes use the 2 or 3 of the global border variables to control which modules, sides and colors they're output at.
+By default, `.border-color-`, `.border-style-` and `.border-width-` classes use the 2 or 3 of the global border variables to control which modules, sides and colors they’re output at.
 
 ```scss
 $hu-border-modules: (base);
@@ -804,7 +804,7 @@ This would allow you to theme your entire application simply by changing a singl
 
 #### Namespace: `$hu-namespace`
 
-As mentioned earlier, Hucssley provides you the opportunity to namespace the class names generated, to help ensure there's no conflict or pollution with other possible frameworks.
+As mentioned earlier, Hucssley provides you the opportunity to namespace the class names generated, to help ensure there’s no conflict or pollution with other possible frameworks.
 
 ```scss
 $hu-namespace: `hu-`;
@@ -814,7 +814,7 @@ $hu-namespace: `hu-`;
 
 #### Debug: `$hu-debug`
 
-With Hucssley generating every class for you, you may encounter scenarios where you need to debug the output when using [webpack's style-loader](https://webpack.js.org/loaders/style-loader) which outputs the CSS within a `<style>` tag in the `<head>`.
+With Hucssley generating every class for you, you may encounter scenarios where you need to debug the output when using [webpack’s style-loader](https://webpack.js.org/loaders/style-loader) which outputs the CSS within a `<style>` tag in the `<head>`.
 
 By setting `$hu-debug: true;` before `@import "hucssley/src/styles";` all of the CSS will be printed to the screen, above your UI for you to review and debug.
 
@@ -867,7 +867,7 @@ While the following examples all use `$-modules` and `$-types` variables that ar
 
 #### Generic classes: `hu-classes`
 
-This mixin generates all of the normal classes for a specific property, modules and types. It's what Hucssley itself uses for 95% of the provided classes.
+This mixin generates all of the normal classes for a specific property, modules and types. It’s what Hucssley itself uses for 95% of the provided classes.
 
 ```
 @mixin hu-classes($property, $modules, $types?);
@@ -907,7 +907,7 @@ It takes a `$property`, which can be either a CSS property or a map, a list of `
 
 ##### Custom class name
 
-By passing a map to `$property`, the map's key becomes the core class name, and the map's value becomes the CSS property.
+By passing a map to `$property`, the map’s key becomes the core class name, and the map’s value becomes the CSS property.
 
 ```scss
 @include hu-classes((fac: align-content), $hu-align-content-modules, $hu-align-content-types);
@@ -1058,7 +1058,7 @@ As with `$hu-classes`, you can customise the class name by passing a map to `$pr
 
 ### Creating new, “more complex” classes
 
-Should you need to create classes that are more complex than what the 3 basic mixins described above can provide, you can follow a defined pattern for creating your own. However, before you do, it's worth having a basic understanding of the functions and mixins you'll use.
+Should you need to create classes that are more complex than what the 3 basic mixins described above can provide, you can follow a defined pattern for creating your own. However, before you do, it’s worth having a basic understanding of the functions and mixins you’ll use.
 
 #### Helper Functions
 
@@ -1075,7 +1075,7 @@ hu-class-name("eqio-<520-flex-wrap-wrap");
 
 ##### `hu-format-modules`
 
-This function removes duplicates and re-orders the list of modules in to the correct specificity order so you needn't worry about this aspect of your CSS.
+This function removes duplicates and re-orders the list of modules in to the correct specificity order so you needn’t worry about this aspect of your CSS.
 
 ```scss
 @function hu-format-modules($list-of-modules);
@@ -1254,13 +1254,13 @@ Generates the responsive `base` and `state` module styles for a pseudo selector 
 */
 ```
 
-Now we have a basic understanding of the functions and mixins used to create classes, we can follow Hucssley's approach to create our own.
+Now we have a basic understanding of the functions and mixins used to create classes, we can follow Hucssley’s approach to create our own.
 
-Let's write some classes to size icons with both `height` and `width` declarations…
+Let’s write some classes to size icons with both `height` and `width` declarations…
 
 #### Defining the variables
 
-As with the OOTB classes, each custom class needs to know which modules it will be created for, and the types and values to use, so let's create the variables for that.
+As with the OOTB classes, each custom class needs to know which modules it will be created for, and the types and values to use, so let’s create the variables for that.
 
 ```scss
 $icon-size-modules: (base, responsive);
@@ -1271,7 +1271,7 @@ $icon-size-types: (
 );
 ```
 
-*Note: Don't prefix custom variables with `hu-` to ensure you don't accidentally overwrite future updates to Hucssley.*
+*Note: Don’t prefix custom variables with `hu-` to ensure you don’t accidentally overwrite future updates to Hucssley.*
 
 #### Writing the class logic
 
@@ -1297,7 +1297,7 @@ Although the mixins described above can take a list of modules, to ensure the co
 }
 ```
 
-The above loop doesn't generate the responsive classes. If we generated them within that `$types` loop, you'd quickly encounter that higher scale base classes would override lower scale responsive classes. By moving them in to a separate loop and block, we can improve build time performance and run-time performance by batching up the media queries to produce smaller output.
+The above loop doesn’t generate the responsive classes. If we generated them within that `$types` loop, you’d quickly encounter that higher scale base classes would override lower scale responsive classes. By moving them in to a separate loop and block, we can improve build time performance and run-time performance by batching up the media queries to produce smaller output.
 
 ```scss
 // only try this if responsive is a module
@@ -1367,7 +1367,7 @@ The output from these 2 blocks is:
 
 ##### Creating custom pseudo classes
 
-One benefit Hucssley has over other, similar libraries is that there is a defined method for easily creating pseudo classes. As with “generic” classes, you'll need 2 code blocks, but instead of calling `hu-generic` and `hu-responsive`, you call `hu-pseudo` and `hu-pseudo-responsive` with the appropriate, documented arguments.
+One benefit Hucssley has over other, similar libraries is that there is a defined method for easily creating pseudo classes. As with “generic” classes, you’ll need 2 code blocks, but instead of calling `hu-generic` and `hu-responsive`, you call `hu-pseudo` and `hu-pseudo-responsive` with the appropriate, documented arguments.
 
 ```scss
 // loop through the formatted modules in order
@@ -1543,11 +1543,11 @@ will generate the following:
 
 ## Creating components
 
-Since Hucssley outputs raw HTML class names, it's incredibly easy to integrate with any front-end “view” framework, to create custom components with small and simple styling APIs.
+Since Hucssley outputs raw HTML class names, it’s incredibly easy to integrate with any front-end “view” framework, to create custom components with small and simple styling APIs.
 
 By using raw class name strings, you are also able to annotate browser-specifc fixes alongside them in the HTML, which helps with understanding why “unnecessary” properties are there.
 
-Let's create a button in Vue:
+Let’s create a button in Vue:
 
 ### Component definition
 
@@ -1642,15 +1642,15 @@ Which means our `template` is as simple as creating an array of the various `sty
 </template>
 ```
 
-The `template` itself is ridiculously simple. You can tell at a glance exactly which class names will be added under any UI condition, and, in the generated HTML you'll even be able to see an IE-specific hack!
+The `template` itself is ridiculously simple. You can tell at a glance exactly which class names will be added under any UI condition, and, in the generated HTML you’ll even be able to see an IE-specific hack!
 
-Unlike alternative frameworks, Hucssley encourages a utility-only, not utility-first mentality, so it's highly recommended that all components be created with a template partial or JavaScript component to keep your code DRY and reduce the opportunity for copy-paste errors.
+Unlike alternative frameworks, Hucssley encourages a utility-only, not utility-first mentality, so it’s highly recommended that all components be created with a template partial or JavaScript component to keep your code DRY and reduce the opportunity for copy-paste errors.
 
 Components with meaningful, semantic props that map to UI variations also reduce the learning curve and implementation for developers less experienced with CSS.
 
 ### Using the component
 
-The following shows how we can quickly use and customise a component's appearance by setting the appropriate props, **and** that we can customise the component on a per-instance basis by merging the passed in `class` attribute with the root component `class` (which happens automagically in Vue).
+The following shows how we can quickly use and customise a component’s appearance by setting the appropriate props, **and** that we can customise the component on a per-instance basis by merging the passed in `class` attribute with the root component `class` (which happens automagically in Vue).
 
 ```html
 <button-hu
@@ -1722,7 +1722,7 @@ The following shows how we can quickly use and customise a component's appearanc
 
 ## Increasing specificity
 
-While all of Hucssley's classes have an intentionally low specificity count, this could present issues if you're integrating it in to an existing project.
+While all of Hucssley’s classes have an intentionally low specificity count, this could present issues if you’re integrating it in to an existing project.
 
 Luckily, since Hucssley is written in Sass, you can easily wrap your imports in a new selector to convert every class to use a descendent selector.
 
@@ -1734,7 +1734,7 @@ Luckily, since Hucssley is written in Sass, you can easily wrap your imports in 
 
 @import "hucssley/src/variables/classes/index";
 // @import "custom/variables/classes/index";
-// set class overrides before if you don't need access to the defaults & want changes to flow through referenced vars
+// set class overrides before if you don’t need access to the defaults & want changes to flow through referenced vars
 
 @import "hucssley/src/variables/reset/index";
 // @import "custom/variables/reset/index";
@@ -1761,7 +1761,7 @@ which will produce:
 
 You could then add the `hucssley` class to a direct ancestor of your newly integrated component, or add it globally to the `<html>` element (although this could have unexpected side-effects if using the reset).
 
-If this still doesn't produce a high enough specificity bump, you can also use the `hu-bump-specificity($increase-to-specificity)` mixin to arbitrarily increase it further:
+If this still doesn’t produce a high enough specificity bump, you can also use the `hu-bump-specificity($increase-to-specificity)` mixin to arbitrarily increase it further:
 
 ```scss
 .hucssley {
@@ -1790,11 +1790,11 @@ which produces:
 
 ## Controlling file size
 
-While Hucssley creates almost every possible class you'd ever want to make building UI simple, this comes at a file size cost with the OOTB CSS coming in at a massive 1.8 MB. Of course, the nature of Hucssley lends itself very well to gzipping, which brings the OOTB CSS down to 114 KB, which ironically, is still a lot smaller than lots of other “production” CSS in the wild.
+While Hucssley creates almost every possible class you’d ever want to make building UI simple, this comes at a file size cost with the OOTB CSS coming in at a massive 1.8 MB. Of course, the nature of Hucssley lends itself very well to gzipping, which brings the OOTB CSS down to 114 KB, which ironically, is still a lot smaller than lots of other “production” CSS in the wild.
 
-Hucssley is infinitely customisable, so you can set the variables of modules you'll never use to `()` so they won't output, and of course, limiting the amount of colors, breakpoints, and spacing scales will also help.
+Hucssley is infinitely customisable, so you can set the variables of modules you’ll never use to `()` so they won’t output, and of course, limiting the amount of colors, breakpoints, and spacing scales will also help.
 
-However, we can do better. And do it automatically. By utilising [Purgecss](https://purgecss.com) and the following `extractor` you'll be able to reduce your CSS output to only the classes that are used in your views:
+However, we can do better. And do it automatically. By utilising [Purgecss](https://purgecss.com) and the following `extractor` you’ll be able to reduce your CSS output to only the classes that are used in your views:
 
 ```js
 extractor: class {

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ translate-x -> transform: translateX
 translate-y -> transform: translateY
 ```
 
-If a value is a negative number, its class name output will use `-n[value]`, such as `margin-l-n100` instead of `margin-l-100`, to make it obvious that it’s “negative” and to not be confused with the “modifying” syntax described below.
+If a value is a negative number, its class name output will use `-n[value]`, such as `margin-l-n100` instead of `margin-l--100`, to make it obvious that it’s “negative” and to not be confused with the “modifying” syntax described below.
 
 If the last two words separated by a hyphen are identical, then the last word will automatically be omitted. For instance `.flex-wrap` is used instead of `flex-wrap-wrap`, but `flex-wrap-no-wrap` would be the equivalent `nowrap` version.
 

--- a/rethinking-css.md
+++ b/rethinking-css.md
@@ -1,16 +1,16 @@
 # Rethinking CSS
 
-In this article, I hope to define what I feel are the biggest issues with CSS, and ultimately, how those issues can be overcome.
+In this article I hope to define what I feel are the biggest issues with CSS and, ultimately, how those issues can be overcome.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- DON’T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
 - [CSS is hard](#css-is-hard)
 - [Bloat is easy](#bloat-is-easy)
 - [Specificity wars](#specificity-wars)
 - [Naming things is hard](#naming-things-is-hard)
-- [What's in a name?](#whats-in-a-name)
+- [What’s in a name?](#whats-in-a-name)
 - [Simpler views](#simpler-views)
 - [Platform agnostic](#platform-agnostic)
 - [Enforce consistency](#enforce-consistency)
@@ -18,7 +18,7 @@ In this article, I hope to define what I feel are the biggest issues with CSS, a
 - [Easily tree-shaken](#easily-tree-shaken)
 - [Performant](#performant)
 - [Easy to learn](#easy-to-learn)
-- [Say hello to Hucssley – Hireup's CSS Library](#say-hello-to-hucssley--hireups-css-library)
+- [Say hello to Hucssley – Hireup’s CSS Library](#say-hello-to-hucssley--hireups-css-library)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -30,79 +30,79 @@ Part of the problem is that CSS is so easy, that everyone on the team, regardles
 
 ## Bloat is easy
 
-Regardless of the technology or methodology used (such as BEM, CSS Modules or some CSS-in-JS library), with a traditional "componentised CSS" approach, the trajectory of your CSS's file size roughly equals the number of features developed. As your product roadmap continues to be implemented, your end users suffer longer download and parse times, and ultimately, a worse user experience.
+Regardless of the technology or methodology used (such as BEM, CSS Modules or some CSS-in-JS library), with a traditional “componentised CSS” approach, the trajectory of your CSS’s file size roughly equals the number of features developed. As your product roadmap continues to be implemented, your end users suffer longer download and parse times and, ultimately, a worse user experience.
 
-While "thinking in components" (be it with help from a library like React or Vue) is absolutely the sensible approach to structuring and scaffolding your views, if 40 components are `display: flex`, why do we write that in a stylesheet 40 times? It's unnecessarily wasteful.
+While “thinking in components” (be it with help from a library like React or Vue) is absolutely the sensible approach to structuring and scaffolding your views, if 40 components are `display: flex`, why do we write that in a stylesheet 40 times? It’s unnecessarily wasteful.
 
-What if we could define an architecture whereby at some threshold, the size of the final CSS would never increase as the project grows?
+What if we could define an architecture whereby, at some threshold, the size of the final CSS would never increase as the project grows?
 
-Teams without dedicated UI Engineers also often reach for some kind pre-fabricated CSS UI framework, such as Bootstrap or Semantic UI, to get them building and realising UI quickly. While the initial development period is promising (foregoing the fact you're now serving to users 200 colours and 20 components you'll never use), bloat continues to worsen as you encounter the next problem…
+Teams without dedicated UI Engineers also often reach for some kind pre-fabricated CSS UI framework, such as Bootstrap or Semantic UI, to get them building and realising UI quickly. While the initial development period is promising (foregoing the fact you’re now serving to users 200 colours and 20 components you’ll never use), bloat continues to worsen as you encounter the next problem…
 
 ## Specificity wars
 
-Specialist UI Engineers have no issue understanding how CSS inheritance works, and also the 3 pillars of the "Cascading" in CSS: importance, specificity and source order. However, any or all of these can and often trip up less familiar developers.
+Specialist UI Engineers have no issue understanding how CSS inheritance works, nor the three pillars of the CSS “Cascade”: importance, specificity and source order. However, any or all of these can and often do trip up less familiar developers.
 
-As you add new features and styles, do they sometimes conflict with existing ones in surprising ways? Do you hack its specificity to get it to work by adding `!important`, an inline `style` or a more "qualified", nested selector? How does this affect the feature you build in 3 months' time? Do you then have to do the same to combat the last hack? It's a never-ending, losing battle.
+As you add new features and styles do they sometimes conflict with existing ones in surprising ways? Do you hack its specificity to get it to work by adding `!important`, an inline `style` or a more “qualified”, nested selector? How does this affect the feature you build in three months’ time? Do you then have to do the same to combat the last hack? It’s a never-ending, losing battle.
 
-Do you know how to calculate specificity? I've been a professional front-end developer since 2002 and I would not be able to reliably calculate it.
+Do you know how to calculate specificity? I’ve been a professional front-end developer since 2002 and I would not be able to reliably calculate it.
 
-But what if we never need to worry about it? What if we could essentially reduce CSS to a meaningful source order (that you're rarely aware of) and UI state helpers that are guaranteed to trump existing styles?
+But what if we never need to worry about it? What if we could essentially reduce CSS to a meaningful source order (that you’re rarely aware of) and UI state helpers that are guaranteed to trump existing styles?
 
 ## Naming things is hard
 
-When BEM was introduced to the front-end community, it was a revelation. Ugly at first, but a revelation nonetheless. Within CSS's global context, it allowed us to clearly express the hierarchy of components: its variants and their children.
+When BEM was introduced to the front-end community it was a revelation. Ugly at first, but a revelation nonetheless. Within CSS’s global context, it allowed us to clearly express the hierarchy of components: its variants and their children.
 
-However, as always with introductory blog post tutorials, real-world usage didn't align with the simplicity presented. How do you describe a discrete child block, that has its own children? How do you define UI states? Are they modifiers or something else entirely? Is that a `wrapper`, a `container` or an `inner`? What do we call the parent class? Is this a `.media-object`? It looks a like a `.flag-layout` to me.
+However, as always with introductory blog post tutorials, real-world usage didn’t align with the simplicity presented. How do you describe a discrete child block, that has its own children? How do you define UI states? Are they modifiers or something else entirely? Is that a `wrapper`, a `container` or an `inner`? What do we call the parent class? Is this a `.media-object`? It looks a like a `.flag-layout` to me.
 
-Of course, CSS Modules freed us from some of these shackles. We no longer needed to worry about such trivial things, or so we were told. It turns out that denoting child hierarchy, however, is actually useful so you can clearly see relationships regardless of whether you're looking at the CSS or HTML.
+Of course, CSS Modules freed us from some of these shackles. We no longer needed to worry about such trivial things, or so we were told. It turns out that denoting child hierarchy, however, is actually useful so you can clearly see relationships regardless of whether you’re looking at the CSS or HTML.
 
-You'll never not have to come up with names for things (your components need to be called something after all), but we can make it so you have less naming decisions to make.
+You’ll never not have to come up with names for things (your components need to be called something after all), but we can make it so you have fewer naming decisions to make.
 
-## What's in a name?
+## What’s in a name?
 
-You know it's name, but what does it do and why does it look that way at this breakpoint, within this context or in this browser? Why does this `.flag-layout` no longer look like a flag when it's in the sidebar?
+You know its name, but what does it do and why does it look that way at this breakpoint, within this context or in this browser? Why does this `.flag-layout` no longer look like a flag when it’s in the sidebar?
 
-By looking at "semantic" class names in HTML alone, it's impossible to know. And of course, if you use a tool that uses/produces obtuse or hashed class names, it's even harder and offers little in regards to performance optimisations anyway.
+By looking at “semantic” class names in HTML alone, it’s impossible to know. And, of course, if you use a tool that uses/produces obtuse or hashed class names it’s even harder, and offers little in regards to performance optimisations anyway.
 
-Once you've found the relevant HTML in your browser's Inspector, you then have to trawl through multiple, overridden, cascaded styles in the CSS Panel to disseminate what you need, which isn't always easy, and only paints the picture for that exact combination of potential scenarios. Every strike-through seen in the inspector represents an inefficiency so should be a potential red flag.
+Once you’ve found the relevant HTML in your browser’s Inspector, you then have to trawl through multiple, overridden, cascaded styles in the CSS Panel to disseminate what you need, which isn’t always easy and only paints the picture for that exact combination of potential scenarios. Every strike-through seen in the inspector represents an inefficiency and should be a potential red flag.
 
-You'll ultimately need to cross-reference what's rendered to the relevant source CSS, and make sure you've understood every permutation.
+You’ll ultimately need to cross-reference what’s rendered to the relevant source CSS, and make sure you’ve understood every permutation.
 
-What if we removed all of this guesswork, and by simply looking at the HTML you could tell exactly how this component is styled and behaves at every possible UI combination?
+What if we removed all of this guesswork and, by simply looking at the HTML, you could tell exactly how this component is styled and behaves at every possible UI combination?
 
 ## Simpler views
 
-When your HTML class attribute explicitly describes all use-cases of a component, your front-end view logic becomes infinitely simpler. You no longer have to mix and match presentational and behavioural logic at run-time; state changes from a user's interaction could effortlessly be achieved by simply adding or removing 1 class name.
+When your HTML class attribute explicitly describes all use-cases of a component, your front-end view logic becomes infinitely simpler. You no longer have to mix and match presentational and behavioural logic at run-time; state changes from a user’s interaction could effortlessly be achieved by simply adding or removing one class name.
 
 ## Platform agnostic
 
-Although the boundaries of the web platform continues to evolve at an ever-increasing pace, the only technologies you can rely on are the core foundations: HTML, CSS and vanilla JavaScript. Everything new and shiny essentially wraps and compiles down to these 3 pillars of web standards.
+Although the boundaries of the web platform continues to evolve at an ever-increasing pace, the only technologies you can rely on are the core foundations: HTML, CSS and vanilla JavaScript. Everything new and shiny essentially wraps and compiles down to these three pillars of web standards.
 
-So what if we had a styling methodology that would not only work regardless of the technology and environmental constraints, but was also easy to implement and port between them? We would be able to support "the web" in whatever shape necessary, whether that's within React, Vue, Elm, Reason, Handlebars, or even HTML emails. There would be no lock-in.
+So what if we had a styling methodology that would not only work regardless of the technology and environmental constraints, but was also easy to implement and port between them? We would be able to support “the web” in whatever shape necessary, whether that’s within React, Vue, Elm, Reason, Handlebars, or even HTML emails. There would be no lock-in.
 
 ## Enforce consistency
 
-CSS is great because it allows you to achieve wild, bespoke things with ease. Conversely, CSS is bad because it allows you to achieve wild, bespoke things with ease. We're not building CSS Zen Garden here. We're building products people need to use daily, and they don't want to have to deal with and continue to re-learn subtle inconsistencies throughout.
+CSS is great because it allows you to achieve wild, bespoke things with ease. Conversely, CSS is bad because it allows you to achieve wild, bespoke things with ease. We’re not building CSS Zen Garden here. We’re building products people need to use daily, and they don’t want to have to deal with and continue to re-learn subtle inconsistencies throughout.
 
-CSS pre-processors and CSS-in-JS libraries help to mitigate this by providing you the opportunity to use variables and functions to ensure we retrieve values from agreed upon standards, but it's purely opt-in. A developer implementing a piece of UI can quite happily go rogue should they wish.
+CSS pre-processors and CSS-in-JS libraries help to mitigate this by providing you the opportunity to use variables and functions to ensure we retrieve values from agreed upon standards, but it’s purely opt-in. A developer implementing a piece of UI can quite happily go rogue should they wish.
 
-What if we removed the ability to stray from our pre-defined path by only ever allowing you to use the CSS/class names that we as a team, have agreed on, and all styling was achieved via classes only?
+What if we removed the ability to stray from our pre-defined path by only ever allowing you to use the CSS/class names that we, as a team, have agreed on and all styling was achieved via classes only?
 
 ## Flexible and customisable
 
-Despite the consistency, it's unrealistic for a product team to understand every possible requirement up front, so any styling solution needs to be flexible and customisable enough to handle these changes in scope.
+Despite the consistency, it’s unrealistic for a product team to understand every possible requirement up front, so any styling solution needs to be flexible and customisable enough to handle these changes in scope.
 
-It should also be flexible in terms of providing the tools to deliver UI that adequately responds to wildly different browser contexts. If a component in browser X at breakpoint Y needs some alteration to deliver the ultimate user experience, then so be it. We shouldn't force our UI to simply settle within arbitrary buckets of breakpoints, for example.
+It should also be flexible in terms of providing the tools to deliver UI that adequately responds to wildly different browser contexts. If a component in browser X at breakpoint Y needs some alteration to deliver the ultimate user experience, then so be it. We shouldn’t force our UI to simply settle within arbitrary buckets of breakpoints, for example.
 
 ## Easily tree-shaken
 
 To combat the bloat factor mentioned earlier, any future-friendly CSS methodology needs to be able to only send over the wire exactly what is required; nothing less, nothing more.
 
-By creating a system that can easily be combined with Purgecss or similar, only CSS that's actually in use will be given to an end user.
+By creating a system that can easily be combined with [Purgecss](https://purgecss.com) or similar, only CSS that’s actually in use will be given to an end user.
 
 ## Performant
 
-As mentioned earlier, if we could create a solution that rarely generates new CSS, our users won't have to endure fetching updated CSS after each deployment, which could quite easily happen multiple times a day.
+As mentioned earlier, if we could create a solution that rarely generates new CSS, our users won’t have to endure fetching updated CSS after each deployment, which could quite easily happen multiple times a day.
 
 With a system that generates consistent, repetitive CSS, even a kitchen-sink stylesheet will compress to something smaller than most traditional CSS approaches. When also removing unused CSS, the end result will be a tiny payload.
 
@@ -110,24 +110,24 @@ Run-time performance should also improve, as the [class selector is the fastest]
 
 ## Easy to learn
 
-What if we could provide a styling solution whose API mostly matches plain CSS 1:1, and then further fixes and improves on some of CSS's known inconsistencies? If you know CSS properties, then you would know this.
+What if we could provide a styling solution whose API mostly matches plain CSS 1:1, and then further fixes and improves on some of CSS’s known inconsistencies? If you know CSS properties then you would know this.
 
-If we combine that with removing the need to juggle specificity, reducing the requirement to name things, having a consistent approach to styling every possible context and encouraging a mobile-first mentality, a developer's cognitive overhead and barrier to entry would be massively reduced.
+If we combine that with removing the need to juggle specificity, reducing the requirement to name things, having a consistent approach to styling every possible context and encouraging a mobile-first mentality, a developer’s cognitive overhead and barrier to entry would be massively reduced.
 
 So, with all that said…
 
-## Say hello to Hucssley – Hireup's CSS Library
+## Say hello to Hucssley – Hireup’s CSS Library
 
-Hucssley is a Sass CSS framework which provides atomic utility classes for rapidly building consistent and performant user interfaces. Using it should hopefully address all of the pain points and support the goals mentioned previously.
+[Hucssley](https://github.com/stowball/hucssley) is a Sass CSS framework which provides atomic utility classes for rapidly building consistent and performant user interfaces. Using it should hopefully address all of the pain points and support the goals mentioned previously.
 
 It is very different to traditional frameworks like Bootstrap or Semantic UI, as it contains zero pre-built UI components, instead providing you with the atomic building blocks necessary for **you** to create any UI component.
 
-This means we will need to re-write all of our UI components from scratch, but it will finally allow us to realise our UX/UI team's dreams for the product without being saddled with all the associated baggage and concessions of 3rd party developers' implementations.
+This means we will need to re-write all of our UI components from scratch, but it will finally allow us to realise our UX/UI team’s dreams for the product without being saddled with all the associated baggage and concessions of 3rd party developers’ implementations.
 
 Hucssley has a few goals:
 
-1. To be incredibly easy to learn and use, by providing a system of atomic classes that mostly map 1:1 with existing CSS properties.
-2. To allow anyone of any skill to rapidly build for the web without unknowingly causing CSS bloat or fighting against some of CSS's core, but sometimes difficult to understand principals.
+1. To be incredibly easy to learn and use by providing a system of atomic classes that mostly map 1:1 with existing CSS properties.
+2. To allow anyone of any skill to rapidly build for the web without unknowingly causing CSS bloat or fighting against some of CSS’s core, but sometimes difficult to understand, principals.
 3. To provide the tools required to build UI for any breakpoint, user interaction or UI state.
 4. To be completely platform agnostic and portable between front-end stacks, with Sass being the only dependency.
 5. To be highly flexible to your needs, with the ability to easily customise existing classes and create new ones.

--- a/rethinking-css.md
+++ b/rethinking-css.md
@@ -1,9 +1,9 @@
 # Rethinking CSS
 
-In this article I hope to define what I feel are the biggest issues with CSS and, ultimately, how those issues can be overcome.
+In this article, I hope to define what I feel are the biggest issues with CSS and, ultimately, how those issues can be overcome.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON’T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
 - [CSS is hard](#css-is-hard)
@@ -50,7 +50,7 @@ But what if we never need to worry about it? What if we could essentially reduce
 
 ## Naming things is hard
 
-When BEM was introduced to the front-end community it was a revelation. Ugly at first, but a revelation nonetheless. Within CSS’s global context, it allowed us to clearly express the hierarchy of components: its variants and their children.
+When BEM was introduced to the front-end community, it was a revelation. Ugly at first, but a revelation nonetheless. Within CSS’s global context, it allowed us to clearly express the hierarchy of components: its variants and their children.
 
 However, as always with introductory blog post tutorials, real-world usage didn’t align with the simplicity presented. How do you describe a discrete child block, that has its own children? How do you define UI states? Are they modifiers or something else entirely? Is that a `wrapper`, a `container` or an `inner`? What do we call the parent class? Is this a `.media-object`? It looks a like a `.flag-layout` to me.
 


### PR DESCRIPTION
- Replaced quotes with curlies.
Find: ([^(`=])"([^"]+)"([^:;)`])
Replace: $1"$2"$3
- Replaced apostrophes with curlies.
Find: (\w)(')([\w\s])
Replace: $1’$3
- Minor tweaks to sentence flow and comma placement.
- Use “fewer” in place of “less” where preferrable (just once).
- Spell out integers under 10.
- Replace ”it's” with “its” as required (just once).
- Add link to Hucssley on Github in case article appears elsewhere.