### PR TITLE
Adds text-decoration-skip-ink reset setting

### DIFF
--- a/src/reset/_index.scss
+++ b/src/reset/_index.scss
@@ -129,6 +129,9 @@
   a {
     display: inline-block #{hu-important()};
     text-decoration: none #{hu-important()};
+    @if ($hu-reset-text-decoration-skip-ink != auto) {
+      text-decoration-skip-ink: $hu-reset-text-decoration-skip-ink #{hu-important()};
+    }
   }
 
   b,

--- a/src/variables/reset/_index.scss
+++ b/src/variables/reset/_index.scss
@@ -9,4 +9,5 @@ $hu-reset-html-overflow-y: null !default;
 $hu-reset-img-responsive: true !default;
 $hu-reset-input-placeholder-color: #767676 !default;
 $hu-reset-remove-number-input-spinners: true !default;
+$hu-reset-text-decoration-skip-ink: auto !default;
 $hu-reset-text-input-appearance: textfield !default;


### PR DESCRIPTION
Just something I think would be useful (and I assume you may like).

If a developer prefers `text-decoration-skip-ink: none` styling then they'd likely want to use it on most projects and it could become a drag/ugly to manually add the CSS in some random location.

I'm sure you've already considered it, so feel free to reject this PR.
