### PR TITLE
Add square brackets to escape classnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -2075,7 +2075,7 @@ However, we can do better… and we can do it automatically. By utilizing [Purge
 ```js
 extractor: class {
   static extract(content) {
-    return content.match(/[A-Za-z0-9-_&:@%\.<>\(\)\/]+/g) || [];
+    return content.match(/[A-Za-z0-9-_&:@%\.<>\(\)\[\]\/]+/g) || [];
   }
 }
 ```

--- a/src/variables/global/_hu-escape-class-name-types.scss
+++ b/src/variables/global/_hu-escape-class-name-types.scss
@@ -1,5 +1,5 @@
 // See https://mathiasbynens.be/notes/css-escapes
-// Use a custom Purgecss extractor: /[A-Za-z0-9-_&:@%\.<>\(\)\/]+/g
+// Use a custom Purgecss extractor: /[A-Za-z0-9-_&:@%\.<>\(\)\[\]\/]+/g
 $hu-escape-class-name-types: (
   ":",
   "&",
@@ -11,4 +11,6 @@ $hu-escape-class-name-types: (
   "/",
   "(",
   ")",
+  "[",
+  "]",
 ) !default;


### PR DESCRIPTION
Add square brackets to escape classnames to allow for attribute selectors