### PR TITLE
Fixed deprecated division syntax

### DIFF
--- a/src/functions/_hu-em.scss
+++ b/src/functions/_hu-em.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @function hu-em($target, $context: 16) {
-  @return hu-strip-unit($target / $context) * 1em;
+  @return hu-strip-unit(math.div($target, $context)) * 1em;
 }

--- a/src/functions/_hu-rem.scss
+++ b/src/functions/_hu-rem.scss
@@ -1,5 +1,7 @@
+@use "sass:math";
+
 $hu-f-rem-context: 16px !default;
 
 @function hu-rem($target, $context: $hu-f-rem-context) {
-  @return hu-strip-unit($target / $context) * 1rem;
+  @return hu-strip-unit(math.div($target, $context)) * 1rem;
 }

--- a/src/functions/_hu-strip-unit.scss
+++ b/src/functions/_hu-strip-unit.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @function hu-strip-unit($number) {
-  @return $number / ($number * 0 + 1);
+  @return math.div($number, $number * 0 + 1);
 }


### PR DESCRIPTION
Noticed a bunch of these warnings after upgrading Sass to v1.35.1. I've run the automated migrator.

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($target, $context)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
2 │   @return hu-strip-unit($target / $context) * 1em;
  │                         ^^^^^^^^^^^^^^^^^^
  ╵
    ../node_modules/hucssley/src/functions/_hu-em.scss 2:25                   hu-em()
    ../node_modules/hucssley/src/variables/global/_hu-media-queries.scss 2:8  @import
    ../node_modules/hucssley/src/variables/global/_index.scss 6:9             @import
```